### PR TITLE
Error message typos

### DIFF
--- a/src/services/bookmarkindex/bookmarkindex.cpp
+++ b/src/services/bookmarkindex/bookmarkindex.cpp
@@ -139,7 +139,7 @@ void BookmarkIndex::buildIndex()
 
 	QFile f(_path);
 	if (!f.open(QIODevice::ReadOnly)) {
-		qWarning() << "[BookmarkIndex]\tCould not open" << _path;
+		qWarning() << "[BookmarkIndex]\tCould not open " << _path;
 		return;
 	}
 

--- a/src/ui/mainwidget/mainwidget.cpp
+++ b/src/ui/mainwidget/mainwidget.cpp
@@ -120,7 +120,7 @@ MainWidget::MainWidget(QWidget *parent)
 	if (_hotkeyManager.hotkey() == 0)
 	{
 		QMessageBox msgBox(QMessageBox::Critical, "Error",
-						   "Hotkey is invalid, please set it. Press Ok to open"\
+						   "Hotkey is invalid, please set it. Press Ok to open "\
 						   "the settings, or press Cancel to quit albert.",
 						   QMessageBox::Close|QMessageBox::Ok);
 		msgBox.exec();

--- a/src/ui/settingsdialog/settingsdialog.cpp
+++ b/src/ui/settingsdialog/settingsdialog.cpp
@@ -165,7 +165,7 @@ void SettingsWidget::closeEvent(QCloseEvent *event)
 {
 	if (_mainWidget->_hotkeyManager.hotkey() == 0){
 		QMessageBox msgBox(QMessageBox::Critical, "Error",
-						   "Hotkey is invalid, please set it. Press Ok to go"\
+						   "Hotkey is invalid, please set it. Press Ok to go "\
 						   "back to the settings, or press Cancel to quit albert.",
 						   QMessageBox::Close|QMessageBox::Ok);
 		msgBox.exec();


### PR DESCRIPTION
I found some spots where a space was missing in error messages.

![screen shot 2015-05-27 at 11 34 47](https://cloud.githubusercontent.com/assets/115889/7833291/f24e34f8-0465-11e5-952a-5e46f5c21ec0.png)
