### PR TITLE
Added optional dependency qt5-svg

### DIFF
--- a/packaging/linux/arch/PKGBUILD
+++ b/packaging/linux/arch/PKGBUILD
@@ -8,6 +8,7 @@ url="https://github.com/ManuelSchneid3r/albert"
 license=('GPL')
 depends=('qt5-base' 'libx11' 'muparser' 'qt5-x11extras')
 makedepends=('cmake' 'qt5-base' 'qt5-tools')
+optdepends=('qt5-svg')
 provides=()
 conflicts=()
 replaces=()


### PR DESCRIPTION
This dependency enables Albert to use icons from installed icon packs