### PR TITLE
Make terminal and su helper customizable.

### DIFF
--- a/src/services/appindex/appindex.cpp
+++ b/src/services/appindex/appindex.cpp
@@ -58,6 +58,8 @@ void AppIndex::restoreDefaults()
 void AppIndex::saveSettings(QSettings &s) const
 {
 	// Save settings
+	s.setValue("Terminal", Item::_termEmu);
+	s.setValue("SuHelper", Item::_suHelper);
 	s.beginGroup("AppIndex");
 	s.setValue("Paths", _paths);
 	s.setValue("SearchType", static_cast<int>(searchType()));
@@ -68,6 +70,8 @@ void AppIndex::saveSettings(QSettings &s) const
 void AppIndex::loadSettings(QSettings &s)
 {
 	// Load settings
+	Item::_termEmu = s.value("Terminal", "konsole").toString();
+	Item::_suHelper = s.value("SuHelper", "kdesu").toString();
 	s.beginGroup("AppIndex");
 	_paths = s.value("Paths", QStandardPaths::standardLocations(
 						 QStandardPaths::ApplicationsLocation)).toStringList();

--- a/src/services/appindex/appitem.cpp
+++ b/src/services/appindex/appitem.cpp
@@ -22,12 +22,15 @@
 #include <QDebug>
 #include <QStandardPaths>
 
+QString AppIndex::Item::_termEmu;
+QString AppIndex::Item::_suHelper;
+
 /**************************************************************************/
 void AppIndex::Item::action()
 {
 	_lastAccess = std::chrono::system_clock::now().time_since_epoch().count();
 	if (_term)
-		QProcess::startDetached("konsole -e " + _exec);
+		QProcess::startDetached(_termEmu + " -e " + _exec);
 	else
 		QProcess::startDetached(_exec);
 
@@ -44,9 +47,9 @@ void AppIndex::Item::altAction()
 {
 	_lastAccess = std::chrono::system_clock::now().time_since_epoch().count();
 	if (_term)
-		QProcess::startDetached("kdesu konsole -e " + _exec);
+		QProcess::startDetached(_suHelper + " " + _termEmu + " -e " + _exec);
 	else
-		QProcess::startDetached("kdesu " + _exec);
+		QProcess::startDetached(_suHelper + " " + _exec);
 }
 
 /**************************************************************************/

--- a/src/services/appindex/appitem.h
+++ b/src/services/appindex/appitem.h
@@ -43,6 +43,8 @@ protected:
 	QString _iconName;
 	QString _exec;
 	bool    _term;
+	static QString _termEmu;
+	static QString _suHelper;
 
 	// Serialization
 	void serialize (QDataStream &out) const override;


### PR DESCRIPTION
Added Terminal and SuHelper to the [General] settings.  Their default
values are konsole and kdesu respectively.