### PR TITLE
Allow launching of terminal applications

### DIFF
--- a/plugins/applications/src/application.cpp
+++ b/plugins/applications/src/application.cpp
@@ -27,6 +27,8 @@ using std::map;
 #include "albertapp.h"
 
 
+QString Applications::Application::terminal;
+
 /** ***************************************************************************/
 QString Applications::Application::name() const {
     return _name;
@@ -52,7 +54,10 @@ QIcon Applications::Application::icon() const {
 void Applications::Application::activate() {
     // Standard action
     qApp->hideWidget();
-    CommandAction(_exec).activate();
+    if(_term)
+        CommandAction(terminal.arg(_exec)).activate();
+    else
+        CommandAction(_exec).activate();
     ++_usage;
 }
 

--- a/plugins/applications/src/application.cpp
+++ b/plugins/applications/src/application.cpp
@@ -141,7 +141,7 @@ bool Applications::Application::readDesktopEntry() {
     _exec.replace("%c", _name);
     _exec.remove(QRegExp("%.")); // Todo standard conform http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
 
-	_term = values["Desktop Entry"]["Terminal"] == "true";
+    _term = values["Desktop Entry"]["Terminal"] == "true";
 
     // Try to get the icon
     if (values["Desktop Entry"].count("Icon"))
@@ -170,7 +170,15 @@ bool Applications::Application::readDesktopEntry() {
 
 
     // Default action
-    _actions.push_back(std::make_shared<DesktopAction>(this, QString("Run %1").arg(_name), _exec, _icon));
+    _actions.push_back(std::make_shared<DesktopAction>(this,
+                                                       QString("Run %1").arg(_name),
+                                                       _exec,
+                                                       _icon,
+                                                       _term));
+
+    // No additional actions for terminal apps
+    if(_term)
+        return true;
 
     // Root actions
     QStringList graphicalSudos({"gksu", "kdesu"});

--- a/plugins/applications/src/application.cpp
+++ b/plugins/applications/src/application.cpp
@@ -118,8 +118,7 @@ bool Applications::Application::readDesktopEntry() {
     } else return false;
 
 
-    if (values["Desktop Entry"]["NoDisplay"] == "true"
-            || values["Desktop Entry"]["Term"] == "true")
+    if (values["Desktop Entry"]["NoDisplay"] == "true")
         return false;
 
 

--- a/plugins/applications/src/application.cpp
+++ b/plugins/applications/src/application.cpp
@@ -141,6 +141,7 @@ bool Applications::Application::readDesktopEntry() {
     _exec.replace("%c", _name);
     _exec.remove(QRegExp("%.")); // Todo standard conform http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s06.html
 
+	_term = values["Desktop Entry"]["Terminal"] == "true";
 
     // Try to get the icon
     if (values["Desktop Entry"].count("Icon"))

--- a/plugins/applications/src/application.h
+++ b/plugins/applications/src/application.h
@@ -50,6 +50,8 @@ public:
     ushort usage() const {return _usage;}
     void incUsage() {++_usage;}
 
+    static QString terminal;
+
 private:
     static QIcon getIcon(const QString &iconStr);
 
@@ -58,6 +60,7 @@ private:
     QString _altName;
     QIcon   _icon;
     QString _exec;
+    bool    _term;
     mutable ushort _usage;
     vector<shared_ptr<A2Item>> _actions;
 };

--- a/plugins/applications/src/configwidget.cpp
+++ b/plugins/applications/src/configwidget.cpp
@@ -15,7 +15,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "configwidget.h"
+#include "application.h"
 #include <QFileDialog>
+#include <QInputDialog>
 #include <QStandardPaths>
 
 /** ***************************************************************************/
@@ -27,6 +29,9 @@ Applications::ConfigWidget::ConfigWidget(QWidget *parent) : QWidget(parent) {
 
     connect(ui.pushButton_removePath, &QPushButton::clicked,
             this, &ConfigWidget::onButton_PathRemove);
+
+    connect(ui.pushButton_terminal, &QPushButton::clicked,
+            this, &ConfigWidget::onButton_Terminal);
 }
 
 
@@ -58,4 +63,20 @@ void Applications::ConfigWidget::onButton_PathRemove() {
     if (ui.listWidget_paths->currentItem() == nullptr)
         return;
     emit requestRemovePath(ui.listWidget_paths->currentItem()->text());
+}
+
+
+
+/** ***************************************************************************/
+void Applications::ConfigWidget::onButton_Terminal() {
+    QString newterm = QInputDialog::getText(
+                this,
+                tr("Terminal Command"),
+                tr("Terminal"),
+                QLineEdit::Normal,
+                Applications::Application::terminal);
+
+    if(newterm.isEmpty())
+        return;
+    Applications::Application::terminal = newterm;
 }

--- a/plugins/applications/src/configwidget.h
+++ b/plugins/applications/src/configwidget.h
@@ -32,6 +32,7 @@ private:
     void onButton_PathAdd();
     void onButton_PathRemove();
     void onButton_RestorePaths();
+    void onButton_Terminal();
 
 signals:
     void requestAddPath(const QString&);

--- a/plugins/applications/src/configwidget.ui
+++ b/plugins/applications/src/configwidget.ui
@@ -94,6 +94,13 @@
           </property>
          </spacer>
         </item>
+        <item>
+         <widget class="QPushButton" name="pushButton_terminal">
+          <property name="text">
+           <string>Terminal</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/plugins/applications/src/desktopaction.cpp
+++ b/plugins/applications/src/desktopaction.cpp
@@ -20,8 +20,8 @@
 
 
 /** ***************************************************************************/
-Applications::DesktopAction::DesktopAction(Application *app, const QString &name, const QString &exec, const QIcon &icon)
-    : app_(app), name_(name), exec_(exec), icon_(icon) {
+Applications::DesktopAction::DesktopAction(Application *app, const QString &name, const QString &exec, const QIcon &icon, const bool term)
+    : app_(app), name_(name), exec_(exec), icon_(icon), term_(term) {
 
 }
 
@@ -51,6 +51,9 @@ QIcon Applications::DesktopAction::icon() const {
 /** ***************************************************************************/
 void Applications::DesktopAction::activate() {
     qApp->hideWidget();
-    return CommandAction(exec_).activate();
+    if(term_)
+        return CommandAction(Application::terminal.arg(exec_)).activate();
+    else
+        return CommandAction(exec_).activate();
     app_->incUsage();
 }

--- a/plugins/applications/src/desktopaction.h
+++ b/plugins/applications/src/desktopaction.h
@@ -24,7 +24,7 @@ class Application;
 class DesktopAction final : public A2Leaf
 {
 public:
-    DesktopAction(Application *app, const QString &name, const QString &exec, const QIcon &icon);
+    DesktopAction(Application *app, const QString &name, const QString &exec, const QIcon &icon, const bool term=false);
 
     QString name() const override;
     QString info() const override;
@@ -36,6 +36,7 @@ private:
     const QString name_;
     const QString exec_;
     const QIcon icon_;
+    const bool term_;
 };
 
 }

--- a/plugins/applications/src/extension.cpp
+++ b/plugins/applications/src/extension.cpp
@@ -74,6 +74,9 @@ void Applications::Extension::initialize() {
     else
         restorePaths();
 
+    // Set terminal emulator
+    Applications::Application::terminal = s.value(CFG_TERM, CFG_TERM_DEF).toString();
+
     // Keep the Applications in sync with the OS
     _updateDelayTimer.setInterval(UPDATE_DELAY);
     _updateDelayTimer.setSingleShot(true);
@@ -118,6 +121,7 @@ void Applications::Extension::finalize() {
     QSettings s;
     s.setValue(CFG_FUZZY, _searchIndex.fuzzy());
     s.setValue(CFG_PATHS, _rootDirs);
+    s.setValue(CFG_TERM, Applications::Application::terminal);
 
     // Serialize data
     QFile dataFile(

--- a/plugins/applications/src/extension.h
+++ b/plugins/applications/src/extension.h
@@ -76,6 +76,8 @@ private:
     static constexpr const char* CFG_PATHS      = "applications/paths";
     static constexpr const char* CFG_FUZZY      = "applications/fuzzy";
     static constexpr const bool  CFG_FUZZY_DEF  = false;
+    static constexpr const char* CFG_TERM       = "applications/terminal";
+    static constexpr const char* CFG_TERM_DEF   = "xterm -e %1";
     static constexpr const bool  UPDATE_DELAY   = 60000;
 
 signals:


### PR DESCRIPTION
This allows albert to launch applications with desktop files that specify "Terminal=true".  A configuration option is added for the applications plugin that specifies the Exec field of the desktop file.  The form is `[term] [options] %1` with `%1` being replaced with the application's exec and defaults to `xterm -e %1`.  A button has been added to the config widget to configure this option.