### PR TITLE
Fix version key in albert.desktop

### DIFF
--- a/src/application/resources/albert.desktop
+++ b/src/application/resources/albert.desktop
@@ -8,4 +8,4 @@ Icon=albert
 Name=Albert
 StartupNotify=false
 Type=Application
-Version=0.7
+Version=1.0


### PR DESCRIPTION
Version refers to the version of the desktop entry specification that the file complies with, not the application version. See http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#recognized-keys.