### PR TITLE
Fixes regarding shutdown and icon handling

### DIFF
--- a/src/application/albertapp.cpp
+++ b/src/application/albertapp.cpp
@@ -104,10 +104,11 @@ AlbertApp::AlbertApp(int &argc, char *argv[]) : QApplication(argc, argv) {
             extensionManager_->registerExtension(p->instance());
 
     // Quit gracefully on SIGTERM
-    signal(SIGTERM, [](int){
+    auto shutdownHandler = [](int){
         QMetaObject::invokeMethod(qApp, "quit", Qt::QueuedConnection);
-    });
-
+    };
+    signal(SIGTERM, shutdownHandler);
+    signal(SIGINT, shutdownHandler);
 
     /*
      *  SETUP SIGNAL FLOW

--- a/src/application/pluginsystem/pluginmanager.cpp
+++ b/src/application/pluginsystem/pluginmanager.cpp
@@ -73,7 +73,7 @@ PluginManager::PluginManager() {
 /** ***************************************************************************/
 PluginManager::~PluginManager() {
     qDebug() << "[PluginManager] Unloading plugins.";
-    QSettings().setValue(CFG_BLACKLIST, blacklist_);
+    storeConfiguration();
     for (const unique_ptr<PluginSpec> &plugin : plugins_){
         unloadPlugin(plugin);
     }
@@ -134,4 +134,11 @@ void PluginManager::disablePlugin(const unique_ptr<PluginSpec> &plugin) {
 /** ***************************************************************************/
 bool PluginManager::pluginIsEnabled(const unique_ptr<PluginSpec> &plugin) {
     return !blacklist_.contains(plugin->id());
+}
+
+
+
+/** ***************************************************************************/
+void PluginManager::storeConfiguration() {
+    QSettings().setValue(CFG_BLACKLIST, blacklist_);
 }

--- a/src/application/pluginsystem/pluginmanager.h
+++ b/src/application/pluginsystem/pluginmanager.h
@@ -38,6 +38,7 @@ public:
     void enablePlugin(const unique_ptr<PluginSpec> &plugin);
     void disablePlugin(const unique_ptr<PluginSpec> &plugin);
     bool pluginIsEnabled(const unique_ptr<PluginSpec> &plugin);
+    void storeConfiguration();
 
 private:
     vector<unique_ptr<PluginSpec>> plugins_;

--- a/src/application/settingswidget/settingswidget.cpp
+++ b/src/application/settingswidget/settingswidget.cpp
@@ -139,6 +139,7 @@ SettingsWidget::SettingsWidget(MainWindow *mainWindow, HotkeyManager *hotkeyMana
 /** ***************************************************************************/
 SettingsWidget::~SettingsWidget() {
     mainWindow_->setHideOnFocusLoss(ui.checkBox_hideOnFocusOut->isChecked()); // Disabled while settings are open
+    pluginManager_->storeConfiguration();
 }
 
 


### PR DESCRIPTION
Hello, I created some fixes for graceful shutdown (handle SIGINT, save settings after settings window is closed), and icon search (home directory was not detected with '~/', and try to use a theme called 'default').

Please take a look into it.