### PR TITLE
Add socket to enforce a single instance

### DIFF
--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(Qt5Widgets 5.2 REQUIRED)
 find_package(Qt5Svg 5.2 REQUIRED)
+find_package(Qt5Network)
 
 include_directories(
     hotkey/
@@ -37,6 +38,7 @@ set(SRC
 set(LIB
     ${Qt5Widgets_LIBRARIES}
     ${Qt5Svg_LIBRARIES}
+    ${Qt5Network_LIBRARIES}
 )
 
 qt5_wrap_ui(UI

--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -1,6 +1,6 @@
 find_package(Qt5Widgets 5.2 REQUIRED)
 find_package(Qt5Svg 5.2 REQUIRED)
-find_package(Qt5Network)
+find_package(Qt5Network REQUIRED)
 
 include_directories(
     hotkey/

--- a/src/application/albertapp.cpp
+++ b/src/application/albertapp.cpp
@@ -134,10 +134,6 @@ AlbertApp::AlbertApp(int &argc, char *argv[]) : QApplication(argc, argv) {
         QMetaObject::invokeMethod(qApp, "quit", Qt::QueuedConnection);
     });
 
-    // Show albert on SIGHUP
-    signal(SIGHUP, [](int){
-        QMetaObject::invokeMethod(qApp, "showWidget", Qt::QueuedConnection);
-    });
 
     /*
      *  SETUP SIGNAL FLOW

--- a/src/application/albertapp.h
+++ b/src/application/albertapp.h
@@ -16,6 +16,8 @@
 
 #pragma once
 #include <QApplication>
+#include <QtNetwork/QLocalServer>
+#include <QtNetwork/QLocalSocket>
 #include <QPointer>
 class MainWindow;
 class HotkeyManager;
@@ -48,5 +50,6 @@ private:
     PluginManager            *pluginManager_;
     ExtensionManager         *extensionManager_;
     QPointer<SettingsWidget> settingsWidget_;
+    QLocalServer             *localServer_;
 };
 

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -17,6 +17,11 @@
 #include "albertapp.h"
 
 int main(int argc, char *argv[]) {
+    QLocalSocket socket;
+    socket.connectToServer("albertapp");
+    if (socket.waitForConnected(500))
+        return EXIT_SUCCESS;
+
     AlbertApp app(argc, argv);
     return app.exec();
 }


### PR DESCRIPTION
This PR adds a QLocalServer to the launcher. When a new instance starts, it attempts to connect. If it successfully connects, the running instance will show the main window and the new instance will close without doing anything.

Fixes #23