### PR TITLE
Adds single instance check

### DIFF
--- a/src/application/CMakeLists.txt
+++ b/src/application/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(Qt5Widgets 5.2 REQUIRED)
 find_package(Qt5Svg 5.2 REQUIRED)
+find_package(Qt5Network REQUIRED)
 
 include_directories(
     hotkey/
@@ -37,6 +38,7 @@ set(SRC
 set(LIB
     ${Qt5Widgets_LIBRARIES}
     ${Qt5Svg_LIBRARIES}
+    ${Qt5Network_LIBRARIES}
 )
 
 qt5_wrap_ui(UI

--- a/src/application/albertapp.cpp
+++ b/src/application/albertapp.cpp
@@ -113,6 +113,16 @@ AlbertApp::AlbertApp(int &argc, char *argv[]) : QApplication(argc, argv) {
     hotkeyManager_ = new HotkeyManager;
     pluginManager_ = new PluginManager;
     extensionManager_ = new ExtensionManager;
+    localServer_ = new QLocalServer(this);
+
+    // Start server so second instances will close
+    QLocalServer::removeServer("albertapp");
+    localServer_->listen("albertapp");
+
+    QObject::connect(localServer_, &QLocalServer::newConnection, [=] () {
+        mainWindow_->show();
+        localServer_->nextPendingConnection()->close();
+    });
 
     // Propagade the extensions once
     for (const unique_ptr<PluginSpec> &p : pluginManager_->plugins())

--- a/src/application/albertapp.h
+++ b/src/application/albertapp.h
@@ -16,6 +16,8 @@
 
 #pragma once
 #include <QApplication>
+#include <QtNetwork/QLocalServer>
+#include <QtNetwork/QLocalSocket>
 #include <QPointer>
 class MainWindow;
 class HotkeyManager;
@@ -48,5 +50,6 @@ private:
     PluginManager            *pluginManager_;
     ExtensionManager         *extensionManager_;
     QPointer<SettingsWidget> settingsWidget_;
+    QLocalServer             *localServer_;
 };
 

--- a/src/application/main.cpp
+++ b/src/application/main.cpp
@@ -17,6 +17,11 @@
 #include "albertapp.h"
 
 int main(int argc, char *argv[]) {
+    QLocalSocket socket;
+    socket.connectToServer("albertapp");
+    if (socket.waitForConnected(500))
+        return EXIT_SUCCESS;
+
     AlbertApp app(argc, argv);
     return app.exec();
 }


### PR DESCRIPTION
Uses QLocalServer to listen for new instances starting. If a new
instance successfully connects to the running instance, the new instance
quits and the existing instance will show the main window.

Future improvements could allow a remote app to control the running
instance, e.g send a command to show the settings or quit.

Fixes #23