### PR TITLE
Fix GenericName in desktop file

### DIFF
--- a/data/albert.desktop
+++ b/data/albert.desktop
@@ -3,7 +3,7 @@
 Categories=Utility;
 Comment=A desktop agnostic launcher
 Exec=albert
-GenericName=Albert
+GenericName=Launcher
 Icon=albert
 Name=Albert
 StartupNotify=false


### PR DESCRIPTION
Per [official specification](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html):
Key: GenericName
Description: Generic name of the application, for example "Web Browser".